### PR TITLE
Add flag for private cloud support

### DIFF
--- a/lib/oraclecloud/client.rb
+++ b/lib/oraclecloud/client.rb
@@ -26,6 +26,7 @@ module OracleCloud
     def initialize(opts)
       @api_url         = opts[:api_url]
       @identity_domain = opts[:identity_domain]
+      @private         = opts[:private] || false
       @username        = opts[:username]
       @password        = opts[:password]
       @verify_ssl      = opts.fetch(:verify_ssl, true)
@@ -87,11 +88,15 @@ module OracleCloud
     end
 
     def username_with_domain
-      "#{compute_identity_domain}/#{@username}"
+      "#{full_identity_domain}/#{@username}"
     end
 
-    def compute_identity_domain
-      "Compute-#{@identity_domain}"
+    def full_identity_domain
+      if @private
+        @identity_domain
+      else
+        "Compute-#{@identity_domain}" 
+      end
     end
 
     def authenticate!
@@ -168,7 +173,7 @@ module OracleCloud
     end
 
     def url_with_identity_domain(type, path = '')
-      "/#{type}/#{compute_identity_domain}/#{path}"
+      "/#{type}/#{full_identity_domain}/#{path}"
     end
 
     def http_get(request_type, url)

--- a/lib/oraclecloud/client.rb
+++ b/lib/oraclecloud/client.rb
@@ -26,7 +26,7 @@ module OracleCloud
     def initialize(opts)
       @api_url         = opts[:api_url]
       @identity_domain = opts[:identity_domain]
-      @private         = opts[:private] || false
+      @private_cloud   = opts[:private_cloud] || false
       @username        = opts[:username]
       @password        = opts[:password]
       @verify_ssl      = opts.fetch(:verify_ssl, true)
@@ -87,15 +87,19 @@ module OracleCloud
       false
     end
 
+    def private_cloud?
+      @private_cloud
+    end
+
     def username_with_domain
       "#{full_identity_domain}/#{@username}"
     end
 
     def full_identity_domain
-      if @private
+      if private_cloud?
         @identity_domain
       else
-        "Compute-#{@identity_domain}" 
+        "Compute-#{@identity_domain}"
       end
     end
 

--- a/lib/oraclecloud/instance_request.rb
+++ b/lib/oraclecloud/instance_request.rb
@@ -48,7 +48,7 @@ module OracleCloud
     end
 
     def full_name
-      "#{client.compute_identity_domain}/#{client.username}/#{name}"
+      "#{client.full_identity_domain}/#{client.username}/#{name}"
     end
 
     def nat

--- a/lib/oraclecloud/orchestrations.rb
+++ b/lib/oraclecloud/orchestrations.rb
@@ -35,9 +35,9 @@ module OracleCloud
 
     def create_request_payload
       {
-        'name' => "#{client.compute_identity_domain}/#{client.username}/#{create_opts[:name]}",
+        'name' => "#{client.full_identity_domain}/#{client.username}/#{create_opts[:name]}",
         'relationships' => [],
-        'account' => "#{client.compute_identity_domain}/default",
+        'account' => "#{client.full_identity_domain}/default",
         'description' => create_opts[:description],
         'schedule' => { 'start_time' => nil, 'stop_time' => nil },
         'uri' => nil,

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -51,17 +51,6 @@ shared_examples_for 'an http caller' do |method, *args|
 end
 
 describe OracleCloud::Client do
-  let(:private_client_opts) do
-    {
-      api_url: 'https://testcloud.oracle.com',
-      identity_domain: 'testdomain',
-      username: 'myuser',
-      password: 'mypassword',
-      private: true
-    }
-  end
-  let(:private_client) { described_class.new(private_client_opts) }
-
   let(:client_opts) do
     {
       api_url: 'https://testcloud.oracle.com',
@@ -77,12 +66,6 @@ describe OracleCloud::Client do
     it 'validates the client options for public cloud' do
       expect(client).to receive(:validate_client_options!)
       client.send(:initialize, client_opts)
-    end
-
-    let(:client) { OracleCloud::Client.allocate }
-    it 'validates the client options for private cloud' do
-      expect(client).to receive(:validate_client_options!)
-      client.send(:initialize, private_client_opts)
     end
   end
 
@@ -152,7 +135,8 @@ describe OracleCloud::Client do
       expect(client.full_identity_domain).to eq('Compute-testdomain')
     end
     it 'returns the raw identity_domain for private compute' do
-      expect(private_client.full_identity_domain).to eq('testdomain')
+      allow(client).to receive(:private_cloud?).and_return(true)
+      expect(client.full_identity_domain).to eq('testdomain')
     end
   end
 

--- a/spec/instance_request_spec.rb
+++ b/spec/instance_request_spec.rb
@@ -128,8 +128,8 @@ describe OracleCloud::InstanceRequest do
   end
 
   describe '#full_name' do
-    it 'returns a properly concatenated string for the name' do
-      allow(client).to receive(:compute_identity_domain).and_return('Compute-testdomain')
+    it 'returns a properly concatenated string for the name in public cloud' do
+      allow(client).to receive(:full_identity_domain).and_return('Compute-testdomain')
       allow(client).to receive(:username).and_return('myuser')
       expect(request.full_name).to eq('Compute-testdomain/myuser/test_name')
     end

--- a/spec/orchestrations_spec.rb
+++ b/spec/orchestrations_spec.rb
@@ -97,13 +97,13 @@ describe OracleCloud::Orchestrations do
 
   describe '#create_request_payload' do
     it 'has a correct name' do
-      allow(client).to receive(:compute_identity_domain).and_return('Compute-testdomain')
+      allow(client).to receive(:full_identity_domain).and_return('Compute-testdomain')
       allow(client).to receive(:username).and_return('myuser')
       expect(orchestrations.create_request_payload['name']).to eq('Compute-testdomain/myuser/test_name')
     end
 
     it 'has a correct account' do
-      allow(client).to receive(:compute_identity_domain).and_return('Compute-testdomain')
+      allow(client).to receive(:full_identity_domain).and_return('Compute-testdomain')
       expect(orchestrations.create_request_payload['account']).to eq('Compute-testdomain/default')
     end
 


### PR DESCRIPTION
This is a potential fix for #3 maintains backwards compatibility and provides a new private flag when creating a client.