### PR TITLE
Fix 'NoMethodError: undefined method `to_json''

### DIFF
--- a/lib/oraclecloud/client.rb
+++ b/lib/oraclecloud/client.rb
@@ -17,6 +17,7 @@
 #
 
 require 'ffi_yajl'
+require 'json'
 require 'rest-client'
 
 module OracleCloud


### PR DESCRIPTION
I experience an issue whereby I receive a nomethoderror for to_json attempting to take actions against the API

```ruby
irb(main):004:0> c = OracleCloud::Client.new(username: 'administrator', password: 'password', identity_domain: 'domain', api_url: 'https://someurl', verify_ssl: false, private_cloud: true)
=> #<OracleCloud::Client:0x007fc16243e3a8 @api_url="https://someurl", @identity_domain="domain", @private_cloud=true, @username="administrator", @password="password", @verify_ssl=false, @cookie=nil>
irb(main):005:0> c.imagelists.all
NoMethodError: undefined method `to_json' for {"user"=>"domain/administrator", "password"=>"password"}:Hash
	from /Users/pauthoma/.rvm/gems/ruby-2.2.2@fogoracle/gems/oraclecloud-1.0.0/lib/oraclecloud/client.rb:111:in `authenticate!'
	from /Users/pauthoma/.rvm/gems/ruby-2.2.2@fogoracle/gems/oraclecloud-1.0.0/lib/oraclecloud/client.rb:184:in `http_get'
	from /Users/pauthoma/.rvm/gems/ruby-2.2.2@fogoracle/gems/oraclecloud-1.0.0/lib/oraclecloud/imagelists.rb:31:in `public_imagelists'
	from /Users/pauthoma/.rvm/gems/ruby-2.2.2@fogoracle/gems/oraclecloud-1.0.0/lib/oraclecloud/imagelists.rb:27:in `all'
	from (irb):5
	from /Users/pauthoma/.rvm/rubies/ruby-2.2.2/bin/irb:11:in `<main>'
```

Explicitly requiring json in client.rb resolves this issue.