### PR TITLE
Use attr_reader for private_cloud instead of def+return pattern.

### DIFF
--- a/lib/oraclecloud/client.rb
+++ b/lib/oraclecloud/client.rb
@@ -22,7 +22,7 @@ require 'rest-client'
 
 module OracleCloud
   class Client # rubocop:disable Metrics/ClassLength
-    attr_reader :identity_domain, :password, :username
+    attr_reader :identity_domain, :password, :username, :private_cloud
 
     def initialize(opts)
       @api_url         = opts[:api_url]
@@ -88,16 +88,12 @@ module OracleCloud
       false
     end
 
-    def private_cloud?
-      @private_cloud
-    end
-
     def username_with_domain
       "#{full_identity_domain}/#{@username}"
     end
 
     def full_identity_domain
-      if private_cloud?
+      if private_cloud
         @identity_domain
       else
         "Compute-#{@identity_domain}"

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -135,7 +135,7 @@ describe OracleCloud::Client do
       expect(client.full_identity_domain).to eq('Compute-testdomain')
     end
     it 'returns the raw identity_domain for private compute' do
-      allow(client).to receive(:private_cloud?).and_return(true)
+      allow(client).to receive(:private_cloud).and_return(true)
       expect(client.full_identity_domain).to eq('testdomain')
     end
   end


### PR DESCRIPTION
Applying this patch resolves a Rubocop error and the adjusted tests
continue to pass with no discernible errors. This change also increases
consistency of approach, as other stuff already uses attr_reader.
There are performance benefits to attr_reader over def+return. [1]

References:
  [1] http://confreaks.tv/videos/rubyconf2010-zomg-why-is-this-code-so-slow